### PR TITLE
Add rel attribute to every instance of new tab

### DIFF
--- a/practice/index.md
+++ b/practice/index.md
@@ -2,8 +2,8 @@
 
 ## This Week's Homework
 
-<a href="https://docs.google.com/document/d/1eHEsEhxqGpF_wHQiPvGGlHZAmntGlYj_I8HKxYtSw6s/edit?usp=sharing" target="_blank">Sept 30: Recursion</a> - 
-<a href="https://forms.gle/PmxfAmeMtk76a2Z27" target="_blank">Submit here</a> - 
+<a href="https://docs.google.com/document/d/1eHEsEhxqGpF_wHQiPvGGlHZAmntGlYj_I8HKxYtSw6s/edit?usp=sharing" target="_blank" rel="noopener noreferrer">Sept 30: Recursion</a> - 
+<a href="https://forms.gle/PmxfAmeMtk76a2Z27" target="_blank" rel="noopener noreferrer">Submit here</a> - 
 (Answers to be posted.)
 
 ## Past Homework

--- a/views/meetings.hbs
+++ b/views/meetings.hbs
@@ -24,7 +24,7 @@
 			{{#each agenda}}
 				<div class="col-md-6 col-lg-4 d-flex align-items-stretch my-2">
 					<div class="card border-0">
-						<a href="{{ this.link }}" target="__blank">
+						<a href="{{ this.link }}" target="__blank" rel="noopener noreferrer">
 							<img class="card-img-top" src="{{ this.img }}" alt="{{ this.title }}">
 						</a>
 						<div class="card-body">
@@ -32,7 +32,7 @@
 							<p class="card-text-custom">{{ this.description }}</p>
 						</div>
 						<div class="card-footer">
-							<a href="{{ this.link }}" class="btn btn-md float-right mt-auto" target="__blank">View Slides</a>
+							<a href="{{ this.link }}" class="btn btn-md float-right mt-auto" target="__blank" rel="noopener noreferrer">View Slides</a>
 						</div>
 					</div>
 				</div>

--- a/views/schedule.hbs
+++ b/views/schedule.hbs
@@ -25,7 +25,7 @@
 			{{#each deadlines}}
 				<div class="py-4 border-bottom border-top">
 					{{#if this.link}}
-						<a href="{{this.link}}" target="_blank"><h3 class="fc-blue">{{this.name}}</h3></a>
+						<a href="{{this.link}}" target="_blank" rel="noopener noreferrer"><h3 class="fc-blue">{{this.name}}</h3></a>
 					{{else}}
 						<h3 class="fc-blue">{{this.name}}</h3>
 					{{/if}}
@@ -51,7 +51,7 @@
 			{{#each upcomingEvents}}
 				{{#if notPastDue}}
 					{{#if this.link}}
-						<h3><a href="{{this.link}}" target="_blank">{{this.name}}</a></h3>
+						<h3><a href="{{this.link}}" target="_blank" rel="noopener noreferrer">{{this.name}}</a></h3>
 					{{else}}
 						<h3>{{this.name}}</h3>
 					{{/if}}
@@ -72,7 +72,7 @@
 			{{#each upcomingEvents}}
 				{{#if pastDue}}
 					{{#if this.link}}
-						<h3><a href="{{this.link}}" target="_blank">{{this.name}}</a></h3>
+						<h3><a href="{{this.link}}" target="_blank" rel="noopener noreferrer">{{this.name}}</a></h3>
 					{{else}}
 						<h3>{{this.name}}</h3>
 					{{/if}}


### PR DESCRIPTION
Sorry for sending a couple PR's within a short amount of time, a former captain gave me a heads-up on a potential vulnerability in my code.

This adds the rel attribute to all instances of opening links in new tabs -- in addition to the recently merged ones -- to avoid the phishing vulnerability it creates.